### PR TITLE
Travis Gradle improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,17 @@
 language: java
+jdk:
+  - openjdk8
+  - openjdk11
+install: {}
+script:
+  - ./gradlew assemble check
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+


### PR DESCRIPTION
* Compile for both OpenJDK8 and 11
* Inhibit the install phase, so the compile warnings are visible in final travis output.
* Override the gradle command to get both assemble and check.
* Cache the gradle caches and wrapper so builds are less expensive.